### PR TITLE
Downgrade JWT 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "require": {
     "craftcms/cms": "^3.3",
-    "lcobucci/jwt": "^3.3",
+    "lcobucci/jwt": "3.3.0",
     "codercat/jwk-to-pem": "^0.0.3"
   },
   "autoload": {


### PR DESCRIPTION
### ISSUE

Not providing the current time is deprecated. Please pass an instance of DateTimeInterface. in /application/vendor/lcobucci/jwt/src/Token.php:299

### FIX

- [ ] The solution is to downgrade the lcobucci/jwt dependency to version ~3.3.0
