### PR TITLE
Compatibility fixes for JWT package version 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "structureit/craft-cognito-auth",
   "description": "Enable authentication to Craft using Amazon Cognito with JWTs",
   "type": "craft-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "craft",
     "cms",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "require": {
     "craftcms/cms": "^3.3",
-    "lcobucci/jwt": "^3.3",
+    "lcobucci/jwt": "^3.4",
     "codercat/jwk-to-pem": "^0.0.3"
   },
   "autoload": {

--- a/src/services/CognitoJWK.php
+++ b/src/services/CognitoJWK.php
@@ -78,7 +78,7 @@ class CognitoJWK extends Component
         $jwkConverter = new JWKConverter();
         $PEM = $jwkConverter->toPEM($jwk);
 
-        // convert to InMemory to satisfy lcobucci deprecation errors
+        // convert to InMemory to satisfy JWT library requirements
         $PEMInMem = new InMemory($PEM);
         return $PEMInMem;
     }

--- a/src/services/CognitoJWK.php
+++ b/src/services/CognitoJWK.php
@@ -15,6 +15,7 @@ use CoderCat\JWKToPEM\JWKConverter;
 use Craft;
 use craft\base\Component;
 use structureit\craftcognitoauth\CraftCognitoAuth;
+use Lcobucci\JWT\Signer\Key\InMemory;
 
 /**
  * @author    Mike Pierce
@@ -76,6 +77,9 @@ class CognitoJWK extends Component
     {
         $jwkConverter = new JWKConverter();
         $PEM = $jwkConverter->toPEM($jwk);
-        return $PEM;
+
+        // convert to InMemory to satisfy lcobucci deprecation errors
+        $PEMInMem = new InMemory($PEM);
+        return $PEMInMem;
     }
 }

--- a/src/services/JWT.php
+++ b/src/services/JWT.php
@@ -20,6 +20,7 @@ use structureit\craftcognitoauth\CraftCognitoAuth;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Rsa\Sha256 as RsaSha256;
 use Lcobucci\JWT\Token;
+use DateTime;
 
 /**
  * @author    Mike Pierce
@@ -85,8 +86,10 @@ class JWT extends Component
      */
     public function verifyJWT(Token $token)
     {
+        // provide explicit DateTimeInterface since lcobucci plugin update now throws errors for an optional param
+        $now = new DateTime();
         // do nothing if token has expired
-        if ($token->isExpired())
+        if ($token->isExpired($now))
             return false;
 
         // check correct claims

--- a/src/services/JWT.php
+++ b/src/services/JWT.php
@@ -86,7 +86,7 @@ class JWT extends Component
      */
     public function verifyJWT(Token $token)
     {
-        // provide explicit DateTimeInterface since lcobucci plugin update now throws errors for an optional param
+        // provide explicit DateTimeInterface to JWT
         $now = new DateTime();
         // do nothing if token has expired
         if ($token->isExpired($now))


### PR DESCRIPTION
### Description

The lcobucci/jwt package used here introduced deprecation error messages in version 3.4, which CraftCMS handles as errors in non-production environments. This is outlined more generally in [this issue](https://github.com/lcobucci/jwt/issues/550). 

This PR now specifies 3.4 as the minimum version, and includes updates to prevent deprecation errors from being thrown.

I believe this is the same issue addressed by #2 

### Definition of Done

- [x] Ensure there are no formatting errors
- [x] Ensure feature branch has latest development code integrated
- [x] Version number in `composer.json` is updated
- [ ] New entry added in `CHANGELOG.md` documenting changes made
